### PR TITLE
update code, python version and functions that are deprecated

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,4 +8,4 @@ name = "pypi"
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+python_version = "3.11"

--- a/pipelines/src/pipelines/xgboost/training/pipeline.py
+++ b/pipelines/src/pipelines/xgboost/training/pipeline.py
@@ -239,7 +239,7 @@ def xgboost_pipeline(
         project_location=project_location,
     ).set_display_name("Import evaluation")
 
-    with dsl.Condition(existing_model != "", "champion-exists"):
+    with dsl.If(existing_model != "", "champion-exists"):
         update_best_model(
             challenger=train_model.outputs["model"],
             challenger_evaluation=evaluation.outputs["model_evaluation"],

--- a/run_auto_dq_scan.yaml
+++ b/run_auto_dq_scan.yaml
@@ -41,7 +41,7 @@ deploymentSpec:
             \ python3 -m pip install --quiet \
             \ --no-warn-script-location 'kfp==2.13.0'\
             \ '--no-deps' 'typing-extensions>=3.7.4,<5; \
-            \ python_version<\"3.9\"' && \"\
+            \ python_version<\"3.11\"' && \"\
             $0\" \"$@\"\n"
           - sh
           - -ec


### PR DESCRIPTION
This PR updates the project to use Python 3.11, and replaces deprecated functions (such as dsl.Condition) with their recommended alternatives (e.g., dsl.If).
All changes have been applied to both the training and prediction pipelines.

How has this been tested?
- Verified that both pipelines (training and prediction) start successfully using the Makefile:
make run PIPELINE_TEMPLATE=xgboost pipeline=training
make run PIPELINE_TEMPLATE=xgboost pipeline=prediction