### PR TITLE
Fix pre-commit infinite loop by removing git-dirty hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,12 +18,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.0.9
+    rev: v0.1.23
     hooks:
       - id: terraform-fmt
+      - id: terraform-validate
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -32,10 +33,6 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
 
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 1.11.0
-    hooks:
-      - id: git-dirty
 
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.3
@@ -44,11 +41,11 @@ repos:
         args: [--format, parsable, --strict]
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.8.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.7.9
+    rev: 7.1.1
     hooks:
       - id: flake8


### PR DESCRIPTION
- Remove git-dirty hook that caused infinite loops with formatters
- Update tool versions to latest stable releases
- Add terraform-validate for validation without formatting conflicts
- This eliminates Windows/Linux line ending compatibility issues

<!-- 
Copyright 2022 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

Please provide a description of the changes you have made in this PR.

# How has this been tested?

Please explain how you have tested the new changes.

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated any relevant documentation to reflect my changes
- [ ] I have assigned a reviewer and messaged them

# Pipeline run links:
